### PR TITLE
Fixes #30 - bad metadata payload for integer attribute.

### DIFF
--- a/dataverse_api/metadata/attributes.py
+++ b/dataverse_api/metadata/attributes.py
@@ -113,7 +113,6 @@ class IntegerAttributeMetadata(AttributeMetadata):
     schema_name : str
     min_value : int
     max_value : int
-    precision : int
     format : dataverse.IntegerFormat
     description : dataverse.Label
     display_name : dataverse.Label
@@ -122,7 +121,6 @@ class IntegerAttributeMetadata(AttributeMetadata):
 
     min_value: int
     max_value: int
-    precision: int = 2
     format: IntegerFormat = Field(default=IntegerFormat.NONE)
 
     def model_post_init(self, __context: Any) -> None:

--- a/tests/metadata/test_attributes.py
+++ b/tests/metadata/test_attributes.py
@@ -1,26 +1,47 @@
-import pytest
-
-from dataverse_api.metadata.attributes import LookupAttributeMetadata, StringAttributeMetadata, StringFormat
+from dataverse_api.metadata.attributes import (
+    AttributeType,
+    AttributeTypeName,
+    IntegerAttributeMetadata,
+    LookupAttributeMetadata,
+    StringAttributeMetadata,
+    StringFormat,
+)
 from dataverse_api.metadata.complex_properties import Label
 
 
-@pytest.fixture
-def lookup_field(description_label: Label, display_name_label: Label) -> LookupAttributeMetadata:
-    return LookupAttributeMetadata(
+def test_lookup_attr(description_label: Label, display_name_label: Label) -> LookupAttributeMetadata:
+    attribute = LookupAttributeMetadata(
         schema_name="Lookup",
         description=description_label,
         display_name=display_name_label,
     )
 
+    attr = attribute.dump_to_dataverse()
 
-def test_lookup(lookup_field: LookupAttributeMetadata):
-    a = lookup_field.dump_to_dataverse()
+    assert len(attr) == 7
+    assert attr["RequiredLevel"] == attribute.required_level.dump_to_dataverse()
+    assert attr["AttributeType"] == AttributeType.LOOKUP.value
+    assert attr["AttributeTypeName"]["Value"] == AttributeTypeName.LOOKUP.value["value"]
+    assert attr["SchemaName"] == attribute.schema_name
 
-    assert len(a) == 7
-    assert a["RequiredLevel"] == lookup_field.required_level.dump_to_dataverse()
-    assert a["AttributeType"] == lookup_field.attribute_type.value  # enum
-    assert a["AttributeTypeName"]["Value"] == lookup_field.attribute_type_name.value["value"]  # enum
-    assert a["SchemaName"] == lookup_field.schema_name
+
+def test_integer_attr(description_label: Label, display_name_label: Label) -> IntegerAttributeMetadata:
+    min, max = -5, 99
+    attribute = IntegerAttributeMetadata(
+        schema_name="Integer",
+        description=description_label,
+        display_name=display_name_label,
+        min_value=min,
+        max_value=max,
+    )
+
+    attr = attribute.dump_to_dataverse()
+
+    assert "Precision" not in attr.keys()
+    assert attr["MinValue"] == min
+    assert attr["MaxValue"] == max
+    assert attr["AttributeType"] == AttributeType.INTEGER.value
+    assert attr["AttributeTypeName"]["Value"] == AttributeTypeName.INTEGER.value["value"]
 
 
 def test_autonumber(description_label: Label, display_name_label: Label):


### PR DESCRIPTION
* `Precision` keyword was specified in metadata payload for integer attributes, this is now removed.