### PR TITLE
fix: use correct header 'MSCRM.SolutionUniqueName' when adding entity to solution in DataverseClient.create_entity()

### DIFF
--- a/dataverse_api/dataverse.py
+++ b/dataverse_api/dataverse.py
@@ -81,7 +81,7 @@ class DataverseClient(Dataverse):
         if return_representation:
             headers["Prefer"] = "return=representation"
         if solution_name:
-            headers["MSCRM.SolutionName"] = solution_name
+            headers["MSCRM.SolutionUniqueName"] = solution_name
 
         return self._api_call(
             method=RequestMethod.POST,


### PR DESCRIPTION
The current implementation uses MSCRM.SolutionName, which does not work when creating entities within a solution context.
According to https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/web-api-metadata-operations-sample Section 1 in the Note Box, the correct header key is MSCRM.SolutionUniqueName.

This PR replaces the incorrect header to ensure entities are correctly added to the target solution.
