### PR TITLE
Add requests as a main dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 dependencies = [
     "narwhals>=1.45.0",
     "pydantic>=2.5.3,<3",
+    "requests>=2.32.4",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dataverse-api"
-version = "1.3.0"
+version = "1.3.1"
 description = "Abstraction layer for interacting with Microsoft Dataverse Web API using Python."
 authors = [{ name = "Marcus Risanger", email = "69350948+MarcusRisanger@users.noreply.github.com" }]
 requires-python = ">=3.11,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -258,7 +258,7 @@ wheels = [
 
 [[package]]
 name = "dataverse-api"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "narwhals" },

--- a/uv.lock
+++ b/uv.lock
@@ -263,6 +263,7 @@ source = { editable = "." }
 dependencies = [
     { name = "narwhals" },
     { name = "pydantic" },
+    { name = "requests" },
 ]
 
 [package.dev-dependencies]
@@ -289,6 +290,7 @@ dev = [
 requires-dist = [
     { name = "narwhals", specifier = ">=1.45.0" },
     { name = "pydantic", specifier = ">=2.5.3,<3" },
+    { name = "requests", specifier = ">=2.32.4" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
The `requests` package was previously installed based on `msal` being listed as a main dependency. Since creating an authenticated session is put on the user, `msal` was removed as a main dependency without re-adding `requests` to main dependency.

Tests don't fail, since tests use the dev environment where `msal` is specified.